### PR TITLE
feat(push): add new options to the push command

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,13 +1,32 @@
 import cli from 'cli-ux';
-import { Command } from '@oclif/command';
+import { Command, flags } from '@oclif/command';
 
 import { Project, MasterFile } from '../models';
 
 export default class Push extends Command {
   static description = 'push master language file';
 
+  static flags = {
+    merge: flags.boolean({
+      description: 'merge strings with the ones on the server (default: true)',
+      default: true,
+      // may be reversed with --no-merge to override server values
+      allowNo: true,
+    }),
+    label: flags.string({
+      description: 'label to assign all changes made during this update',
+    }),
+    'ignore-missing': flags.boolean({
+      description: 'disable obsoleting missing strings (default: true)',
+      default: true,
+      // may be reversed with --no-ignore-missing to obsolete missing strings
+      allowNo: true,
+    }),
+  };
+
   async run() {
     const { projectFiles } = await Project.init();
+    const { flags } = this.parse(Push);
 
     let masterFile = projectFiles.filter(
       (file) => file.master_project_file_id === null
@@ -17,7 +36,8 @@ export default class Push extends Command {
 
     await new MasterFile(masterFile.id).update(
       masterFile.name,
-      masterFile.locale_code
+      masterFile.locale_code,
+      flags
     );
 
     cli.action.stop(

--- a/src/models/MasterFile.ts
+++ b/src/models/MasterFile.ts
@@ -79,13 +79,30 @@ export class MasterFile {
     }
   }
 
-  async update(name: string, locale: string) {
+  async update(
+    name: string,
+    locale: string,
+    options: {
+      merge: boolean;
+      'ignore-missing': boolean;
+      label?: string;
+    }
+  ) {
     try {
       const file = fs.createReadStream(process.cwd() + `/${name}`);
 
       const formData = new FormData();
       formData.append('file', file);
       formData.append('name', name);
+      if (options.merge) {
+        formData.append('merge', 'true');
+      }
+      if (options['ignore-missing']) {
+        formData.append('ignore_missing', 'true');
+      }
+      if (options.label) {
+        formData.append('label', options.label);
+      }
 
       await wtiPut(`/files/${this._masterFileId}/locales/${locale}`, formData);
     } catch (err) {


### PR DESCRIPTION
- `--merge`: to merge strings with the ones on the server (default:
  true)
- `--no-merge`
- `--label`: label to assign all changes made during this update
- `--ignore-missing`: disable obsoleting missing strings (default: true)
- `--no-ignore-missing`

By default now, WTI is the source of truth

- if a string is on WTI but missing in an MR, it is not obsoleted
- if a string has a different value on WTI than on local, when pushing, the local one won't override the WTI one